### PR TITLE
Add initial Docker registry UI scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Docker Registry UI
+
+A minimal project providing a web-based interface for browsing a private Docker registry.
+
+## Project Structure
+
+- `src/backend` - ASP.NET Core Web API that communicates with a Docker registry.
+- `src/frontend` - React + TypeScript single page application.
+
+## Development
+
+1. Start the backend API (requires .NET 8 SDK):
+
+```bash
+cd src/backend
+DOTNET_ENVIRONMENT=Development dotnet run
+```
+
+2. Start the frontend dev server (requires Node.js):
+
+```bash
+cd src/frontend
+npm install
+npm start
+```
+
+The frontend is configured to proxy `/api` requests to the backend.

--- a/src/backend/DockerRegistryUi.Api.csproj
+++ b/src/backend/DockerRegistryUi.Api.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/src/backend/Program.cs
+++ b/src/backend/Program.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System.Net.Http.Json;
+
+var builder = WebApplication.CreateBuilder(args);
+var services = builder.Services;
+
+services.AddEndpointsApiExplorer();
+services.AddSwaggerGen();
+services.AddHttpClient();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+var registryUrl = builder.Configuration["REGISTRY_URL"] ?? "http://localhost:5000";
+var singleRegistry = builder.Configuration.GetValue("SINGLE_REGISTRY", true);
+
+app.MapGet("/api/repositories", async (HttpClient http) =>
+{
+    var catalog = await http.GetFromJsonAsync<Catalog>($"{registryUrl}/v2/_catalog");
+    return Results.Json(catalog ?? new Catalog());
+});
+
+app.MapGet("/api/repositories/{name}/tags", async (HttpClient http, string name) =>
+{
+    var tags = await http.GetFromJsonAsync<TagList>($"{registryUrl}/v2/{name}/tags/list");
+    return Results.Json(tags ?? new TagList());
+});
+
+app.Run();
+
+record Catalog(string[] repositories = null!);
+record TagList(string name = null!, string[] tags = null!);

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -1,0 +1,20 @@
+# Docker Registry UI Backend
+
+Minimal ASP.NET Core API that proxies requests to a Docker registry.
+
+## Configuration
+
+Environment variables:
+
+- `REGISTRY_URL` - URL to the Docker registry (default `http://localhost:5000`).
+- `SINGLE_REGISTRY` - `true` to operate in single registry mode. Defaults to `true`.
+
+## Development
+
+Build and run:
+
+```bash
+# Ensure .NET 8 SDK is installed
+dotnet restore
+dotnet run
+```

--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -1,0 +1,14 @@
+# Docker Registry UI Frontend
+
+This is a minimal React + TypeScript frontend for browsing a Docker registry.
+
+## Development
+
+Install dependencies and start the dev server:
+
+```bash
+npm install
+npm start
+```
+
+The dev server proxies API requests to `http://localhost:5000`.

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "docker-registry-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "webpack serve --mode development --open",
+    "build": "webpack --mode production"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "ts-loader": "^9.0.0",
+    "webpack": "^5.0.0",
+    "webpack-cli": "^5.0.0",
+    "webpack-dev-server": "^4.0.0"
+  }
+}

--- a/src/frontend/public/index.html
+++ b/src/frontend/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Docker Registry UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="/bundle.js"></script>
+  </body>
+</html>

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+
+interface Repository {
+  name: string;
+}
+
+const App: React.FC = () => {
+  const [repos, setRepos] = useState<Repository[]>([]);
+
+  useEffect(() => {
+    fetch('/api/repositories')
+      .then(res => res.json())
+      .then(data => setRepos(data.repositories || []));
+  }, []);
+
+  return (
+    <div>
+      <h1>Docker Registry UI</h1>
+      <ul>
+        {repos.map(repo => (
+          <li key={repo.name}>{repo.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default App;

--- a/src/frontend/src/index.tsx
+++ b/src/frontend/src/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(<App />);
+}

--- a/src/frontend/tsconfig.json
+++ b/src/frontend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "commonjs",
+    "jsx": "react",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/src/frontend/webpack.config.js
+++ b/src/frontend/webpack.config.js
@@ -1,0 +1,31 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.tsx',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js',
+    publicPath: '/',
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  devServer: {
+    static: {
+      directory: path.join(__dirname, 'public'),
+    },
+    historyApiFallback: true,
+    proxy: {
+      '/api': 'http://localhost:5000'
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- set up React frontend with TypeScript and webpack
- add ASP.NET Core backend with endpoints for registry catalog and tags
- document how to run frontend and backend

## Testing
- `npm run build` *(fails: webpack not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68627d107268832f8ff0d34d122757cb