### PR TITLE
Add tag manifest endpoint and UI update

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ npm start
 ```
 
 The frontend is configured to proxy `/api` requests to the backend.
+
+## Features
+
+- Browse repositories in the registry.
+- View tags for a repository and inspect the manifest for a given tag.

--- a/src/backend/Program.cs
+++ b/src/backend/Program.cs
@@ -33,6 +33,15 @@ app.MapGet("/api/repositories/{name}/tags", async (HttpClient http, string name)
     return Results.Json(tags ?? new TagList());
 });
 
+app.MapGet("/api/repositories/{name}/tags/{tag}", async (HttpClient http, string name, string tag) =>
+{
+    using var request = new HttpRequestMessage(HttpMethod.Get, $"{registryUrl}/v2/{name}/manifests/{tag}");
+    request.Headers.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json");
+    var response = await http.SendAsync(request);
+    var manifestJson = await response.Content.ReadAsStringAsync();
+    return Results.Content(manifestJson, "application/json");
+});
+
 app.Run();
 
 record Catalog(string[] repositories = null!);

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -18,3 +18,9 @@ Build and run:
 dotnet restore
 dotnet run
 ```
+
+## Endpoints
+
+- `GET /api/repositories` - list repositories from the registry.
+- `GET /api/repositories/{name}/tags` - list tags for the given repository.
+- `GET /api/repositories/{name}/tags/{tag}` - fetch manifest details for the specified tag.

--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -12,3 +12,5 @@ npm start
 ```
 
 The dev server proxies API requests to `http://localhost:5000`.
+
+The UI lets you select a repository, view its tags and inspect the manifest for a tag.

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -6,6 +6,10 @@ interface Repository {
 
 const App: React.FC = () => {
   const [repos, setRepos] = useState<Repository[]>([]);
+  const [selectedRepo, setSelectedRepo] = useState<string | null>(null);
+  const [tags, setTags] = useState<string[]>([]);
+  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [manifest, setManifest] = useState<any | null>(null);
 
   useEffect(() => {
     fetch('/api/repositories')
@@ -13,14 +17,49 @@ const App: React.FC = () => {
       .then(data => setRepos(data.repositories || []));
   }, []);
 
+  const loadTags = (repo: string) => {
+    setSelectedRepo(repo);
+    setSelectedTag(null);
+    setManifest(null);
+    fetch(`/api/repositories/${repo}/tags`)
+      .then(res => res.json())
+      .then(data => setTags(data.tags || []));
+  };
+
+  const loadManifest = (tag: string) => {
+    if (!selectedRepo) return;
+    setSelectedTag(tag);
+    fetch(`/api/repositories/${selectedRepo}/tags/${tag}`)
+      .then(res => res.json())
+      .then(data => setManifest(data));
+  };
+
   return (
     <div>
       <h1>Docker Registry UI</h1>
-      <ul>
-        {repos.map(repo => (
-          <li key={repo.name}>{repo.name}</li>
-        ))}
-      </ul>
+      {selectedRepo ? (
+        <div>
+          <button onClick={() => setSelectedRepo(null)}>Back</button>
+          <h2>{selectedRepo}</h2>
+          <ul>
+            {tags.map(t => (
+              <li key={t} onClick={() => loadManifest(t)}>{t}</li>
+            ))}
+          </ul>
+          {selectedTag && manifest && (
+            <div>
+              <h3>{selectedTag}</h3>
+              <pre>{JSON.stringify(manifest, null, 2)}</pre>
+            </div>
+          )}
+        </div>
+      ) : (
+        <ul>
+          {repos.map(repo => (
+            <li key={repo.name} onClick={() => loadTags(repo.name)}>{repo.name}</li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add endpoint to fetch manifest for a repository tag
- display repository tags and manifest in the UI
- document new endpoint and features

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: webpack not found)*
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686296222c6c832fbe3daf06d7c66f1d